### PR TITLE
Implement `make-load-form` for colors

### DIFF
--- a/types.lisp
+++ b/types.lisp
@@ -99,6 +99,9 @@ space denoted by COLOR-TYPE."
   (print-unreadable-object (color stream :type t :identity t)
     (princ (multiple-value-list (color-coordinates color)) stream)))
 
+(defmethod make-load-form ((object color-object) &optional environment)
+  (make-load-form-saving-slots object :environment environment))
+
 (export 'rgb-color-object)
 (defclass rgb-color-object (color-object)
   ((r


### PR DESCRIPTION
I'm not sure if you're interested in PRs from Github, but I figured I'd try.

Some implementations (e.g. CCL) are particularly aggressive about inlining
constants, and will fail during compilation without a way to dump them into
FASLs:

```
[ClozureCL] COMMON-LISP-USER> (ql:quickload 'rs-colors)
...
> Error: No MAKE-LOAD-FORM method is defined for #<CIE-XYY-COLOR (0.34567 0.3585 1) #x302001EC0A0D>
```

Implementing a really simple `make-load-form` fixes the problem.
